### PR TITLE
Add Ensure Initialized for GetCompressedLogs and Custom Layout Support

### DIFF
--- a/MetroLog.Net6/MicrosoftExtensions/ConsoleLoggerProvider.cs
+++ b/MetroLog.Net6/MicrosoftExtensions/ConsoleLoggerProvider.cs
@@ -1,15 +1,15 @@
+using MetroLog.Layouts;
 using MetroLog.Targets;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace MetroLog.MicrosoftExtensions;
 
-
 [ProviderAlias("Console")]
 public class ConsoleLoggerProvider : LoggerProviderBase
 {
     public ConsoleLoggerProvider(IOptions<LoggerOptions> options)
-        : base(new ConsoleTarget(), options.Value)
+        : base(new ConsoleTarget(options.Value.Layout ?? new SingleLineLayout()), options.Value)
     {
     }
 }

--- a/MetroLog.Net6/MicrosoftExtensions/InMemoryLoggerProvider.cs
+++ b/MetroLog.Net6/MicrosoftExtensions/InMemoryLoggerProvider.cs
@@ -1,3 +1,4 @@
+using MetroLog.Layouts;
 using MetroLog.Targets;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -13,7 +14,7 @@ public class InMemoryLoggerOptions : LoggerOptions
 public class InMemoryLoggerProvider : LoggerProviderBase
 {
     public InMemoryLoggerProvider(IOptions<InMemoryLoggerOptions> options)
-        : base(new MemoryTarget(maxLines: options.Value.MaxLines ?? 1024), options.Value)
+        : base(new MemoryTarget(options.Value.MaxLines ?? 1024, options.Value.Layout ?? new SingleLineLayout()), options.Value)
     {
     }
 }

--- a/MetroLog.Net6/MicrosoftExtensions/LoggerProviderBase.cs
+++ b/MetroLog.Net6/MicrosoftExtensions/LoggerProviderBase.cs
@@ -1,3 +1,4 @@
+using MetroLog.Layouts;
 using MetroLog.Targets;
 using Microsoft.Extensions.Logging;
 
@@ -12,7 +13,9 @@ public class LoggerOptions
 
     public virtual Microsoft.Extensions.Logging.LogLevel? MinLevel { get; set; }
 
-    public virtual Microsoft.Extensions.Logging.LogLevel? MaxLevel { get; set;  }
+    public virtual Microsoft.Extensions.Logging.LogLevel? MaxLevel { get; set; }
+
+    public virtual Layout? Layout { get; set; }
 }
 
 public abstract class LoggerProviderBase : ILoggerProvider

--- a/MetroLog.Net6/MicrosoftExtensions/StreamingFileLoggerProvider.cs
+++ b/MetroLog.Net6/MicrosoftExtensions/StreamingFileLoggerProvider.cs
@@ -1,3 +1,4 @@
+using MetroLog.Layouts;
 using MetroLog.Targets;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -19,6 +20,7 @@ public class StreamingFileLoggerProvider : LoggerProviderBase
     public StreamingFileLoggerProvider(IOptions<StreamingFileLoggerOptions> options)
         : base(
             new StreamingFileTarget(
+                options.Value.Layout ?? new SingleLineLayout(),
                 logsDirectoryPath: options.Value.FolderPath,
                 retainDays: options.Value.RetainDays ?? 30,
                 fileNamingParameters: options.Value.FileNamingParameters),

--- a/MetroLog.Net6/MicrosoftExtensions/TraceLoggerProvider.cs
+++ b/MetroLog.Net6/MicrosoftExtensions/TraceLoggerProvider.cs
@@ -1,15 +1,15 @@
+using MetroLog.Layouts;
 using MetroLog.Targets;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace MetroLog.MicrosoftExtensions;
 
-
 [ProviderAlias("Trace")]
 public class TraceLoggerProvider : LoggerProviderBase
 {
     public TraceLoggerProvider(IOptions<LoggerOptions> options)
-        : base(new TraceTarget(), options.Value)
+        : base(new TraceTarget(options.Value.Layout ?? new SingleLineLayout()), options.Value)
     {
     }
 }

--- a/MetroLog.Net6/Targets/FileTargetBase.cs
+++ b/MetroLog.Net6/Targets/FileTargetBase.cs
@@ -12,9 +12,9 @@ public abstract class FileTargetBase : AsyncTarget, ILogCompressor
 {
     protected const string LogFolderName = "MetroLogs";
 
-    private readonly AsyncLock _lock = new ();
+    private readonly AsyncLock _lock = new();
 
-    private readonly Dictionary<string, StreamWriter> _openStreamWriters = new ();
+    private readonly Dictionary<string, StreamWriter> _openStreamWriters = new();
 
     protected FileTargetBase(
         Layout layout,
@@ -62,6 +62,7 @@ public abstract class FileTargetBase : AsyncTarget, ILogCompressor
         using (await _lock.LockAsync().ConfigureAwait(false))
         {
             CloseAllOpenStreamsInternal();
+            await EnsureInitialized().ConfigureAwait(false);
             return await GetCompressedLogsInternal().ConfigureAwait(false);
         }
     }
@@ -87,7 +88,7 @@ public abstract class FileTargetBase : AsyncTarget, ILogCompressor
 
     protected abstract Task<Stream> GetWritableStreamForFile(string fileName);
 
-    protected sealed override async Task<LogWriteOperation> WriteAsyncCore(LogWriteContext context, LogEventInfo entry)
+    protected override sealed async Task<LogWriteOperation> WriteAsyncCore(LogWriteContext context, LogEventInfo entry)
     {
         var contents = Layout.GetFormattedString(context, entry);
         using (await _lock.LockAsync().ConfigureAwait(false))

--- a/MetroLog.Net6/Targets/MemoryTarget.cs
+++ b/MetroLog.Net6/Targets/MemoryTarget.cs
@@ -9,10 +9,15 @@ public class MemoryTarget : SyncTarget, ILogLister
     private readonly int _maxLines;
     private readonly Queue<string> _queue;
 
-    private readonly AsyncLock _lock = new ();
+    private readonly AsyncLock _lock = new();
 
     public MemoryTarget(int maxLines = 1024)
-        : base(new SingleLineLayout())
+        : this(maxLines, new SingleLineLayout())
+    {
+    }
+
+    public MemoryTarget(int maxLines, Layout layout)
+        : base(layout)
     {
         _maxLines = maxLines;
         _queue = new Queue<string>(maxLines);

--- a/MetroLogSample.Maui/Layouts/SimpleLayout.cs
+++ b/MetroLogSample.Maui/Layouts/SimpleLayout.cs
@@ -1,0 +1,13 @@
+﻿using MetroLog;
+using Layout = MetroLog.Layouts.Layout;
+
+namespace MetroLogSample.Maui.Layouts
+{
+    public class SimpleLayout : Layout
+    {
+        public override string GetFormattedString(LogWriteContext context, LogEventInfo info)
+        {
+            return $"{info.TimeStamp:G} - {info.Level}: {info.Message}";
+        }
+    }
+}

--- a/MetroLogSample.Maui/MauiProgram.cs
+++ b/MetroLogSample.Maui/MauiProgram.cs
@@ -1,5 +1,6 @@
 ﻿using MetroLog.MicrosoftExtensions;
 using MetroLog.Operators;
+using MetroLogSample.Maui.Layouts;
 using Microsoft.Extensions.Logging;
 
 namespace MetroLogSample.Maui;
@@ -23,6 +24,7 @@ public static class MauiProgram
                 {
                     options.MinLevel = LogLevel.Trace;
                     options.MaxLevel = LogLevel.Critical;
+                    options.Layout = new SimpleLayout();
                 }) // Will write to the Debug Output
             .AddConsoleLogger(
                 options =>

--- a/MetroLogSample.Maui/Platforms/Android/MainActivity.cs
+++ b/MetroLogSample.Maui/Platforms/Android/MainActivity.cs
@@ -2,7 +2,7 @@
 using Android.Content.PM;
 using Android.OS;
 
-namespace MetroLog.Maui.Sample;
+namespace MetroLogSample.Maui;
 
 [Activity(
     Theme = "@style/Maui.SplashTheme",

--- a/MetroLogSample.Maui/Platforms/Tizen/Main.cs
+++ b/MetroLogSample.Maui/Platforms/Tizen/Main.cs
@@ -2,15 +2,15 @@ using System;
 using Microsoft.Maui;
 using Microsoft.Maui.Hosting;
 
-namespace MetroLog.Maui.Sample;
+namespace MetroLogSample.Maui;
 
 class Program : MauiApplication
 {
-	protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
 
-	static void Main(string[] args)
-	{
-		var app = new Program();
-		app.Run(args);
-	}
+    static void Main(string[] args)
+    {
+        var app = new Program();
+        app.Run(args);
+    }
 }

--- a/MetroLogSample.Maui/Platforms/Windows/App.xaml
+++ b/MetroLogSample.Maui/Platforms/Windows/App.xaml
@@ -1,8 +1,6 @@
 ﻿<maui:MauiWinUIApplication
-    x:Class="MetroLog.Maui.Sample.WinUI.App"
+    x:Class="MetroLogSample.Maui.WinUI.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:maui="using:Microsoft.Maui"
-    xmlns:local="using:MetroLog.Maui.Sample.WinUI">
-
-</maui:MauiWinUIApplication>
+    xmlns:local="using:MetroLogSample.Maui.WinUI"
+    xmlns:maui="using:Microsoft.Maui" />

--- a/MetroLogSample.Maui/Platforms/Windows/App.xaml.cs
+++ b/MetroLogSample.Maui/Platforms/Windows/App.xaml.cs
@@ -3,7 +3,7 @@
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 
-namespace MetroLog.Maui.Sample.WinUI;
+namespace MetroLogSample.Maui.WinUI;
 
 /// <summary>
 /// Provides application-specific behavior to supplement the default Application class.
@@ -21,4 +21,3 @@ public partial class App : MauiWinUIApplication
 
     protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
 }
-

--- a/MetroLogSample.Maui/Platforms/Windows/app.manifest
+++ b/MetroLogSample.Maui/Platforms/Windows/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-    <assemblyIdentity version="1.0.0.0" name="MetroLog.Maui.Sample.WinUI.app"/>
+    <assemblyIdentity version="1.0.0.0" name="MetroLogSample.Maui.WinUI.app" />
 
     <application xmlns="urn:schemas-microsoft-com:asm.v3">
         <windowsSettings>


### PR DESCRIPTION
- Ensure Initialized before call to GetCompressedLogsInternal. (Fixes #11)
- Unify root namespace in sample project to MetroLogSample.Maui.
- Add Layout to LoggerOptions for custom layout support. (Fixes #7)
- Add SimpleLayout to sample project.