### PR TITLE
Return null instead of throwing NotSupportedException in MicrosoftLoggerWrapper.BeginScope

### DIFF
--- a/MetroLog.Net6/MicrosoftExtensions/MicrosoftLoggerWrapper.cs
+++ b/MetroLog.Net6/MicrosoftExtensions/MicrosoftLoggerWrapper.cs
@@ -28,7 +28,8 @@ public class MicrosoftLoggerWrapper : Microsoft.Extensions.Logging.ILogger
 
     public IDisposable BeginScope<TState>(TState state)
     {
-        throw new NotSupportedException("BeginScope is not supported on MetroLog");
+        // BeginScope is not supported on MetroLog
+        return null;#
     }
 }
 

--- a/MetroLog.Net6/MicrosoftExtensions/MicrosoftLoggerWrapper.cs
+++ b/MetroLog.Net6/MicrosoftExtensions/MicrosoftLoggerWrapper.cs
@@ -29,7 +29,7 @@ public class MicrosoftLoggerWrapper : Microsoft.Extensions.Logging.ILogger
     public IDisposable BeginScope<TState>(TState state)
     {
         // BeginScope is not supported on MetroLog
-        return null;#
+        return null;
     }
 }
 


### PR DESCRIPTION
Fix for issue https://github.com/roubachof/MetroLog/issues/6