### PR TITLE
Fix close button for .net8

### DIFF
--- a/MetroLog.Maui/MetroLogPage.xaml
+++ b/MetroLog.Maui/MetroLogPage.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:ios="clr-namespace:Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;assembly=Microsoft.Maui.Controls"
@@ -21,6 +21,7 @@
                   ColumnDefinitions="100,*,100">
                 <Button x:Name="Close"
                         Grid.Column="0"
+                        HorizontalOptions="Start"
                         VerticalOptions="End"
                         Text="Close"
                         Clicked="OnCloseClicked"/>


### PR DESCRIPTION
In .net8, the close button does not show.
replicated and tested, in android 15 and iOS 18.2
Fixes issue #49